### PR TITLE
test(any): strengthen weak assertClassSchemaEquals checks

### DIFF
--- a/test/@types/jest.d.ts
+++ b/test/@types/jest.d.ts
@@ -1,3 +1,4 @@
+import Joi = require('joi');
 import { Validator } from '../../src/validation';
 
 interface ToBeValidOptions {
@@ -9,10 +10,12 @@ declare global {
     namespace jest {
         interface Matchers<R> {
             toBeValid(options?: ToBeValidOptions): void;
+            toMatchSchemaMap(expectedSchemaMap: Joi.SchemaMap): void;
         }
 
         interface Expect {
             toBeValid(options?: ToBeValidOptions): void;
+            toMatchSchemaMap(expectedSchemaMap: Joi.Schema): void;
         }
     }
 }

--- a/test/helpers/setup.ts
+++ b/test/helpers/setup.ts
@@ -1,3 +1,6 @@
+import * as Joi from 'joi';
+import { omit } from 'lodash';
+import { getJoi, getJoiSchema } from '../../src/core';
 import { Validator } from '../../src/validation';
 import { ToBeValidOptions } from '../@types/jest';
 
@@ -27,6 +30,31 @@ expect.extend({
         const message =
             `expected candidate to ${isNot ? 'fail' : 'pass'} validation` +
             (!candidateAsString ? '' : `:\n\n  ${candidateAsString.replace(/\n/gm, '\n  ')}\n\n${errorMessage}`.trim());
+
+        return {
+            pass,
+            message: () => message,
+        };
+    },
+    toMatchSchemaMap(Class: any, expectedSchemaMap: Joi.SchemaMap, options?: { joi?: typeof Joi }) {
+        const SCHEMA_PROPERTIES_TO_IGNORE = ['$_super'];
+
+        const trimSchema = (schema: Joi.ObjectSchema<any> | undefined) =>
+            schema && omit(schema, SCHEMA_PROPERTIES_TO_IGNORE);
+
+        // tslint:disable-next-line:no-invalid-this
+        const isNot = this.isNot;
+        let pass = false;
+        let message = `expected Class to ${isNot ? 'not ' : ''}have schema matching expected schema`;
+        const joi = getJoi(options);
+        const schema = getJoiSchema(Class, joi);
+        const expectedSchema = joi.object().keys(expectedSchemaMap);
+
+        try {
+            expect(trimSchema(schema)).toEqual(trimSchema(expectedSchema));
+            pass = true;
+        } catch {
+        }
 
         return {
             pass,

--- a/test/unit/decorators/any.test.ts
+++ b/test/unit/decorators/any.test.ts
@@ -1,5 +1,5 @@
 import * as Joi from 'joi';
-import { testConstraint, assertClassSchemaEquals } from '../testUtil';
+import { testConstraint } from '../testUtil';
 import * as jf from '../../../src';
 import { getJoiSchema } from '../../../src/core';
 import { Validator, isValidationPass } from '../../../src/validation';
@@ -281,13 +281,15 @@ describe('any', () => {
         }
 
         it('should associate a label with the property', () => {
-            assertClassSchemaEquals({
-                Class: LoginForm,
-                expectedSchemaMap: {
-                    username: jf.joi.string().label('Username'),
-                    password: jf.joi.string().label('Password'),
-                    rememberMe: jf.joi.boolean().label('Keep me logged in'),
-                },
+            expect(LoginForm).toMatchSchemaMap({
+                username: jf.joi.string().label('Username'),
+                password: jf.joi.string().label('Password'),
+                rememberMe: jf.joi.boolean().label('Keep me logged in'),
+            });
+            expect(LoginForm).not.toMatchSchemaMap({
+                username: jf.joi.string(),
+                password: jf.joi.string(),
+                rememberMe: jf.joi.boolean(),
             });
         });
     });
@@ -299,11 +301,11 @@ describe('any', () => {
         }
 
         it('should associate a label with the property', () => {
-            assertClassSchemaEquals({
-                Class: User,
-                expectedSchemaMap: {
-                    name: jf.joi.string().meta({ value: 'some metadata' }),
-                },
+            expect(User).toMatchSchemaMap({
+                name: jf.joi.string().meta({ value: 'some metadata' }),
+            });
+            expect(User).not.toMatchSchemaMap({
+                name: jf.joi.string(),
             });
         });
     });
@@ -315,11 +317,11 @@ describe('any', () => {
         }
 
         it('should associate notes with the property', () => {
-            assertClassSchemaEquals({
-                Class: User,
-                expectedSchemaMap: {
-                    name: jf.joi.string().note('some notes'),
-                },
+            expect(User).toMatchSchemaMap({
+                name: jf.joi.string().note('some notes'),
+            });
+            expect(User).not.toMatchSchemaMap({
+                name: jf.joi.string(),
             });
         });
     });
@@ -353,11 +355,11 @@ describe('any', () => {
         }
 
         it('should override validation options for the property', () => {
-            assertClassSchemaEquals({
-                Class: User,
-                expectedSchemaMap: {
-                    name: jf.joi.string().options({ presence: 'required' }),
-                },
+            expect(User).toMatchSchemaMap({
+                name: jf.joi.string().options({ presence: 'required' }),
+            });
+            expect(User).not.toMatchSchemaMap({
+                name: jf.joi.string(),
             });
         });
     });
@@ -451,13 +453,15 @@ describe('any', () => {
                 password!: string;
             }
 
-            assertClassSchemaEquals({
-                Class: User,
-                expectedSchemaMap: {
-                    id: jf.joi.string().tag('identity'),
-                    emailAddress: jf.joi.string().tag('identity', 'authentication'),
-                    password: jf.joi.string().tag('authentication'),
-                },
+            expect(User).toMatchSchemaMap({
+                id: jf.joi.string().tag('identity'),
+                emailAddress: jf.joi.string().tag('identity', 'authentication'),
+                password: jf.joi.string().tag('authentication'),
+            });
+            expect(User).not.toMatchSchemaMap({
+                id: jf.joi.string(),
+                emailAddress: jf.joi.string(),
+                password: jf.joi.string(),
             });
         });
     });
@@ -469,11 +473,11 @@ describe('any', () => {
                 radius!: number;
             }
 
-            assertClassSchemaEquals({
-                Class: Circle,
-                expectedSchemaMap: {
-                    radius: jf.joi.number().unit('millimetres'),
-                },
+            expect(Circle).toMatchSchemaMap({
+                radius: jf.joi.number().unit('millimetres'),
+            });
+            expect(Circle).not.toMatchSchemaMap({
+                radius: jf.joi.number(),
             });
         });
     });

--- a/test/unit/testUtil.ts
+++ b/test/unit/testUtil.ts
@@ -3,7 +3,7 @@ import { rootPath } from 'get-root-path';
 import * as path from 'path';
 import * as fs from 'fs';
 import { Validator } from '../../src/validation';
-import { AnyClass, getJoiSchema, getJoi, parseVersionString } from '../../src/core';
+import { parseVersionString } from '../../src/core';
 
 export function notNil<T>(value: T): Exclude<T, null | undefined> {
     if (value === null || value === undefined) {
@@ -88,15 +88,6 @@ export function testConversion<T>(options: TestConversionOptions<T>) {
             });
         });
     }
-}
-
-export function assertClassSchemaEquals(
-    options: { Class: AnyClass, expectedSchemaMap: Joi.SchemaMap, joi?: typeof Joi },
-) {
-    const joi = getJoi(options);
-    const schema = getJoiSchema(options.Class, joi);
-    const expectedSchema = joi.object().keys(options.expectedSchemaMap);
-    expect(Object.keys(schema!)).toEqual(Object.keys(expectedSchema));
 }
 
 interface PackageDependencies {


### PR DESCRIPTION
Hi Simon,

Sorry for the late re-review of your wonderful Joiful contributions. I've just taken another look and had a crack at improving the checking of the previous `assertClassSchemaEquals` function. Please have a look. If you agree with these changes, please merge them into your branch before we accept your PR into Joiful's master branch. 👍 

Cheers,
Benji